### PR TITLE
get_match_detail 테스트 케이스 삭제

### DIFF
--- a/Kartrider.Api.Test/Endpoints/Match/GetMatchDetailTests.cs
+++ b/Kartrider.Api.Test/Endpoints/Match/GetMatchDetailTests.cs
@@ -8,17 +8,6 @@ namespace Kartrider.Api.Test.Endpoints.Match
     [TestClass]
     public class GetMatchDetailTests : TestBase
     {
-        [DataTestMethod]
-        [DataRow("036e0001f656572a", DisplayName = "아이템 팀 배틀모드: 036e0001f656572a")]
-        [DataRow("036a000ef64df337", DisplayName = "스피드 개인전: 036a000ef64df337")]
-        [DataRow("0343000ef64d9a4a", DisplayName = "스피드 개인전: 0343000ef64d9a4a")]
-        [DataRow("03210018f64ff810", DisplayName = "스피드 팀전: 03210018f64ff810")]
-        [DataRow("02080018f64fe39e", DisplayName = "스피드 팀전: 02080018f64fe39e")]
-        [DataRow("00d40009f64d9038", DisplayName = "아이템 팀전: 00d40009f64d9038")]
-        public async Task Get_Match_Detail(string matchId)
-        {
-            await kartriderApi.Match.GetMatchDetailAsync(matchId);
-        }
         [TestMethod("존재하지 않은 매치 상세 정보")]
         public async Task Get_Match_Detail_NotFound()
         {


### PR DESCRIPTION
테스트에 사용된 매치 데이터의 유효기간이 1년이 넘었으므로 테스트를 삭제함
## Reference
+ [[공지] 카트라이더 매치데이터 제공기간 변경 안내](https://developers.nexon.com/kart/noticeDetail/1/135847)